### PR TITLE
Add Curios Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,10 @@ repositories {
         name = "The Loader"
         url = "https://maven.blamejared.com"
     }
+    maven {
+        // Curios
+        url = "https://maven.theillusivec4.top/"
+    }
 }
 
 dependencies {
@@ -120,6 +124,9 @@ dependencies {
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
 
     compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.4:7.1.0.84")
+    
+    runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}")
+    compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ minecraft_version=1.16.3
 #Mod dependencies
 jei_version=7.6.0.49
 patchouli_version=1.16.4-48-SNAPSHOT
+curios_version=1.16.4-4.0.3.5

--- a/src/main/java/wayoftime/bloodmagic/BloodMagic.java
+++ b/src/main/java/wayoftime/bloodmagic/BloodMagic.java
@@ -23,6 +23,7 @@ import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -52,6 +53,7 @@ import wayoftime.bloodmagic.common.data.recipe.BloodMagicRecipeProvider;
 import wayoftime.bloodmagic.common.item.BloodMagicItems;
 import wayoftime.bloodmagic.common.registries.BloodMagicEntityTypes;
 import wayoftime.bloodmagic.common.registries.BloodMagicRecipeSerializers;
+import wayoftime.bloodmagic.compat.CuriosCompat;
 import wayoftime.bloodmagic.core.AnointmentRegistrar;
 import wayoftime.bloodmagic.core.LivingArmorRegistrar;
 import wayoftime.bloodmagic.core.recipe.IngredientBloodOrb;
@@ -95,6 +97,9 @@ public class BloodMagic
 
 	public static final BloodMagicPacketHandler packetHandler = new BloodMagicPacketHandler();
 	public static final RitualManager RITUAL_MANAGER = new RitualManager();
+
+	public static Boolean curiosLoaded;
+	public static final CuriosCompat curiosCompat = new CuriosCompat();
 
 	public BloodMagic()
 	{
@@ -185,6 +190,11 @@ public class BloodMagic
 		LivingArmorRegistrar.register();
 		AnointmentRegistrar.register();
 		AlchemyArrayRegistry.registerBaseArrays();
+
+		if (curiosLoaded)
+		{
+			curiosCompat.registerInventory();
+		}
 	}
 
 	public void registerTileEntityTypes(RegistryEvent.Register<TileEntityType<?>> event)
@@ -245,6 +255,8 @@ public class BloodMagic
 //		LOGGER.info("HELLO FROM PREINIT");
 //		LOGGER.info("DIRT BLOCK >> {}", Blocks.DIRT.getRegistryName());
 		packetHandler.initialize();
+
+		curiosLoaded = ModList.get().isLoaded("curios");
 	}
 
 //	@OnlyIn(Dist.CLIENT)
@@ -276,6 +288,11 @@ public class BloodMagic
 //			LOGGER.info("Hello world from the MDK");
 //			return "Hello world";
 //		});
+
+		if (curiosLoaded)
+		{
+			curiosCompat.setupSlots(event);
+		}
 	}
 
 	private void processIMC(final InterModProcessEvent event)

--- a/src/main/java/wayoftime/bloodmagic/api/IBloodMagicAPI.java
+++ b/src/main/java/wayoftime/bloodmagic/api/IBloodMagicAPI.java
@@ -1,5 +1,6 @@
 package wayoftime.bloodmagic.api;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
@@ -8,7 +9,9 @@ import org.apache.logging.log4j.LogManager;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.LazyValue;
+import net.minecraft.util.NonNullList;
 
 /**
  * The main interface between a plugin and Blood Magic's internals.
@@ -121,6 +124,18 @@ public interface IBloodMagicAPI
 	 * @param value           The amount of tranquility that the handler has
 	 */
 	default void registerTranquilityHandler(Predicate<BlockState> predicate, String tranquilityType, double value)
+	{
+	}
+
+	/**
+	 * Registers a {@link Function<PlayerEntity, NonNullList<ItemStack>>} for
+	 * inventory handling.
+	 * 
+	 * @param inventoryIdentifier String identifier for the inventory.
+	 * @param function            Function which inputs a Player Entity and outputs
+	 *                            a NonNullList of ItemStacks.
+	 */
+	default void registerInventoryProvider(String inventoryIdentifier, Function<PlayerEntity, NonNullList<ItemStack>> provider)
 	{
 	}
 

--- a/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
+++ b/src/main/java/wayoftime/bloodmagic/compat/CuriosCompat.java
@@ -1,0 +1,39 @@
+package wayoftime.bloodmagic.compat;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.fml.InterModComms;
+import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
+import net.minecraftforge.items.IItemHandler;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotTypeMessage;
+import top.theillusivec4.curios.api.SlotTypePreset;
+import wayoftime.bloodmagic.impl.BloodMagicAPI;
+
+public class CuriosCompat
+{
+	public void setupSlots(InterModEnqueueEvent evt)
+	{
+		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.NECKLACE.getMessageBuilder().build());
+		InterModComms.sendTo("curios", SlotTypeMessage.REGISTER_TYPE, () -> SlotTypePreset.CHARM.getMessageBuilder().build());
+	}
+
+	public void registerInventory()
+	{
+		BloodMagicAPI.INSTANCE.registerInventoryProvider("curiosInventory", player -> getCuriosInventory(player));
+	}
+
+	public NonNullList<ItemStack> getCuriosInventory(PlayerEntity player)
+	{
+		IItemHandler itemHandler = CuriosApi.getCuriosHelper().getEquippedCurios(player).resolve().get();
+
+		NonNullList<ItemStack> inventory = NonNullList.create();
+		for (int i = 0; i < itemHandler.getSlots(); i++)
+		{
+			inventory.add(itemHandler.getStackInSlot(i));
+		}
+		return inventory;
+	}
+
+}

--- a/src/main/java/wayoftime/bloodmagic/impl/BloodMagicAPI.java
+++ b/src/main/java/wayoftime/bloodmagic/impl/BloodMagicAPI.java
@@ -1,6 +1,9 @@
 package wayoftime.bloodmagic.impl;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
@@ -10,6 +13,8 @@ import com.google.common.collect.Multimap;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import wayoftime.bloodmagic.altar.ComponentType;
 import wayoftime.bloodmagic.api.IBloodMagicAPI;
 import wayoftime.bloodmagic.api.compat.EnumDemonWillType;
@@ -28,6 +33,7 @@ public class BloodMagicAPI implements IBloodMagicAPI
 	private final BloodMagicRecipeRegistrar recipeRegistrar;
 	private final BloodMagicValueManager valueManager;
 	private final Multimap<ComponentType, BlockState> altarComponents;
+	private final Map<String, Function<PlayerEntity, NonNullList<ItemStack>>> inventoryProvider;
 
 	public BloodMagicAPI()
 	{
@@ -35,6 +41,7 @@ public class BloodMagicAPI implements IBloodMagicAPI
 		this.recipeRegistrar = new BloodMagicRecipeRegistrar();
 		this.valueManager = new BloodMagicValueManager();
 		this.altarComponents = ArrayListMultimap.create();
+		this.inventoryProvider = new HashMap<String, Function<PlayerEntity, NonNullList<ItemStack>>>();
 	}
 
 	@Nonnull
@@ -56,6 +63,12 @@ public class BloodMagicAPI implements IBloodMagicAPI
 	public BloodMagicValueManager getValueManager()
 	{
 		return valueManager;
+	}
+
+	@Nonnull
+	public Map<String, Function<PlayerEntity, NonNullList<ItemStack>>> getInventoryProvider()
+	{
+		return inventoryProvider;
 	}
 
 	@Override
@@ -98,6 +111,12 @@ public class BloodMagicAPI implements IBloodMagicAPI
 		{
 			BMLog.API.warn("Invalid Tranquility type: {}.", tranquilityType);
 		}
+	}
+
+	@Override
+	public void registerInventoryProvider(String inventoryIdentifier, Function<PlayerEntity, NonNullList<ItemStack>> provider)
+	{
+		inventoryProvider.put(inventoryIdentifier, provider);
 	}
 
 	@Override

--- a/src/main/java/wayoftime/bloodmagic/impl/BloodMagicCorePlugin.java
+++ b/src/main/java/wayoftime/bloodmagic/impl/BloodMagicCorePlugin.java
@@ -56,5 +56,9 @@ public class BloodMagicCorePlugin
 		apiInterface.registerAltarComponent(BloodMagicBlocks.ORB_RUNE.get().getDefaultState(), ComponentType.BLOODRUNE.name());
 		apiInterface.registerAltarComponent(BloodMagicBlocks.ACCELERATION_RUNE.get().getDefaultState(), ComponentType.BLOODRUNE.name());
 		apiInterface.registerAltarComponent(BloodMagicBlocks.CHARGING_RUNE.get().getDefaultState(), ComponentType.BLOODRUNE.name());
+
+		apiInterface.registerInventoryProvider("mainInventory", player -> player.inventory.mainInventory);
+		apiInterface.registerInventoryProvider("armorInventory", player -> player.inventory.armorInventory);
+		apiInterface.registerInventoryProvider("offHandInventory", player -> player.inventory.offHandInventory);
 	}
 }

--- a/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/util/handler/event/GenericHandler.java
@@ -61,6 +61,7 @@ import wayoftime.bloodmagic.network.DemonAuraClientPacket;
 import wayoftime.bloodmagic.potion.BMPotionUtils;
 import wayoftime.bloodmagic.potion.BloodMagicPotions;
 import wayoftime.bloodmagic.util.helper.BindableHelper;
+import wayoftime.bloodmagic.util.helper.InventoryHelper;
 import wayoftime.bloodmagic.util.helper.NetworkHelper;
 import wayoftime.bloodmagic.util.helper.PlayerHelper;
 import wayoftime.bloodmagic.will.DemonWillHolder;
@@ -272,7 +273,7 @@ public class GenericHandler
 
 		if (!player.getEntityWorld().isRemote)
 		{
-			for (ItemStack stack : player.inventory.mainInventory)
+			for (ItemStack stack : InventoryHelper.getAllInventories(player))
 			{
 				if (stack.getItem() instanceof ItemExperienceBook)
 				{

--- a/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
+++ b/src/main/java/wayoftime/bloodmagic/util/helper/InventoryHelper.java
@@ -1,0 +1,29 @@
+package wayoftime.bloodmagic.util.helper;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import wayoftime.bloodmagic.impl.BloodMagicAPI;
+
+public class InventoryHelper
+{
+
+	/**
+	 * Gets all items from all registered inventories.
+	 * 
+	 * @param player - The player who's inventories to check.
+	 * @return - NonNullList<ItemStack> of all items in those inventories.
+	 */
+	public static NonNullList<ItemStack> getAllInventories(PlayerEntity player)
+	{
+		Map<String, Function<PlayerEntity, NonNullList<ItemStack>>> inventoryProvider = BloodMagicAPI.INSTANCE.getInventoryProvider();
+		NonNullList<ItemStack> inventory = NonNullList.create();
+
+		inventoryProvider.forEach((identifier, provider) -> inventory.addAll(provider.apply(player)));
+
+		return inventory;
+	}
+}

--- a/src/main/java/wayoftime/bloodmagic/will/PlayerDemonWillHandler.java
+++ b/src/main/java/wayoftime/bloodmagic/will/PlayerDemonWillHandler.java
@@ -6,6 +6,7 @@ import net.minecraft.util.NonNullList;
 import wayoftime.bloodmagic.api.compat.EnumDemonWillType;
 import wayoftime.bloodmagic.api.compat.IDemonWill;
 import wayoftime.bloodmagic.api.compat.IDemonWillGem;
+import wayoftime.bloodmagic.util.helper.InventoryHelper;
 import wayoftime.bloodmagic.util.helper.NetworkHelper;
 
 /**
@@ -25,7 +26,8 @@ public class PlayerDemonWillHandler
 	 */
 	public static double getTotalDemonWill(EnumDemonWillType type, PlayerEntity player)
 	{
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 		double souls = 0;
 
 		for (ItemStack stack : inventory)
@@ -68,7 +70,7 @@ public class PlayerDemonWillHandler
 	 */
 	public static boolean isDemonWillFull(EnumDemonWillType type, PlayerEntity player)
 	{
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 
 		boolean hasGem = false;
 		for (ItemStack stack : inventory)
@@ -95,7 +97,7 @@ public class PlayerDemonWillHandler
 	{
 		double consumed = 0;
 
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 
 		for (int i = 0; i < inventory.size(); i++)
 		{
@@ -130,7 +132,7 @@ public class PlayerDemonWillHandler
 		if (willStack.isEmpty())
 			return ItemStack.EMPTY;
 
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 
 		for (ItemStack stack : inventory)
 		{
@@ -156,7 +158,7 @@ public class PlayerDemonWillHandler
 	 */
 	public static double addDemonWill(EnumDemonWillType type, PlayerEntity player, double amount)
 	{
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 		double remaining = amount;
 
 		for (ItemStack stack : inventory)
@@ -184,7 +186,7 @@ public class PlayerDemonWillHandler
 	 */
 	public static double addDemonWill(EnumDemonWillType type, PlayerEntity player, double amount, ItemStack ignored)
 	{
-		NonNullList<ItemStack> inventory = player.inventory.mainInventory;
+		NonNullList<ItemStack> inventory = InventoryHelper.getAllInventories(player);
 		double remaining = amount;
 
 		for (ItemStack stack : inventory)

--- a/src/main/resources/data/curios/tags/items/charm.json
+++ b/src/main/resources/data/curios/tags/items/charm.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "bloodmagic:miningsigil",
+    "bloodmagic:growthsigil",
+    "bloodmagic:sigilofmagnetism",
+    "bloodmagic:icesigil",
+    "bloodmagic:sigilofholding",
+    "bloodmagic:experiencebook"
+  ]
+}

--- a/src/main/resources/data/curios/tags/items/necklace.json
+++ b/src/main/resources/data/curios/tags/items/necklace.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "bloodmagic:soulgempetty",
+    "bloodmagic:soulgemlesser",
+    "bloodmagic:soulgemcommon",
+    "bloodmagic:soulgemgreater"
+  ]
+}


### PR DESCRIPTION
Add Curios Support for Tartaric Gems (Necklace) , Sigils (Charm), and the Tome of Peritia (Charm).

* Add Curios API to the Dev Environment.
* Item Tag Tartaric Gems as a Curios Necklace, and relevant Sigils and Tome of Peritia as Curios Charms.
* Load CuriosCompat from BloodMagic.java if Curios is installed.
* Adjust the Blood Magic API to register an inventory provider.
* CuriosCompat uses an IMC to request at least 1 Necklace and 1 Charm slot to be available to the player, and registers the Curios Inventory with the API.
* Made an InventoryHelper class.  Right now it only has one method which returns all available API inventory items.
* Adjusted PlayerDemonWillHandler and Generic Handler (Tome of Peritia's XP event listener) to use the new InventoryHelper.